### PR TITLE
update link to tfsec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN GO111MODULE="on" go get github.com/terraform-docs/terraform-docs@${versionTe
 FROM golang:1.13 as tfsec
 
 # to force the docker cache to invalidate when there is a new version
-RUN env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec
+RUN env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec
 
 
 ###########################################################


### PR DESCRIPTION
the current docker cache invalidation step pulls from redirected URL which can cause unreliablilty when building.  Updated to the literal URL.

Sample error when attempting to build:

```
Step 11/42 : RUN env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec
 ---> Running in 1ef389ce9ae0
go: finding github.com/liamg/tfsec v0.30.1
go: downloading github.com/liamg/tfsec v0.30.1
go: extracting github.com/liamg/tfsec v0.30.1
go get: github.com/liamg/tfsec@v0.30.1: parsing go.mod:
        module declares its path as: github.com/tfsec/tfsec
                but was required as: github.com/liamg/tfsec
```

Simple edit ... but why not.