### PR TITLE
Adding -p --plan to save plan to external location

### DIFF
--- a/scripts/rover.sh
+++ b/scripts/rover.sh
@@ -103,6 +103,10 @@ while (( "$#" )); do
                 tf_output_file=${2}
                 shift 2
                 ;;
+        -p|--plan)
+                tf_output_plan_file=${2}
+                shift 2
+                ;;
         -w|--workspace)
                 export TF_VAR_workspace=${2}
                 shift 2
@@ -147,6 +151,7 @@ process_target_subscription
 echo ""
 echo "mode                          : '$(echo ${caf_command})'"
 echo "terraform command output file : '$(echo ${tf_output_file})'"
+echo "terraform plan output file    : '$(echo ${tf_output_plan_file})'"
 echo "tf_action                     : '$(echo ${tf_action})'"
 echo "command and parameters        : '$(echo ${tf_command})'"
 echo ""

--- a/scripts/tfc.sh
+++ b/scripts/tfc.sh
@@ -145,6 +145,11 @@ function plan_tfc {
         -state="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_name}" \
         -out="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_plan}" $PWD 2>$STDERR_FILE | tee ${tf_output_file}
 
+    if [ ! -z ${tf_output_plan_file} ]; then
+        echo "Copying plan file to ${tf_output_plan_file}"
+        cp "${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_plan}" "${tf_output_plan_file}"
+    fi
+
     RETURN_CODE=$? && echo "Terraform plan return code: ${RETURN_CODE}"
 
     if [ -s $STDERR_FILE ]; then

--- a/scripts/tfstate_azurerm.sh
+++ b/scripts/tfstate_azurerm.sh
@@ -175,6 +175,11 @@ function plan {
         -state="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_name}" \
         -out="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_plan}" $PWD 2>$STDERR_FILE | tee ${tf_output_file}
 
+    if [ ! -z ${tf_output_plan_file} ]; then
+        echo "Copying plan file to ${tf_output_plan_file}"
+        cp "${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_plan}" "${tf_output_plan_file}"
+    fi
+
     RETURN_CODE=$? && echo "Terraform plan return code: ${RETURN_CODE}"
 
     if [ -s $STDERR_FILE ]; then


### PR DESCRIPTION
Hello,

We use the tfplan file after running a plan to detect any misconfiguration before running an apply using https://www.checkov.io/ . Checkov requires a binary tfplan file so the current `-o|--output` does not meet our needs, although it's certainly very useful to keep the human readable output that `-o|--output` produces. 

We noticed that rover removes the plan file after running when there is an exciting launchpad. I can see it being useful to keep a copy of the tfplan binary after a plan. 

I have added an extra `-p|--plan` parameter to specify the location to copy the tfplan to and updated `plan_tfc` to copy the file to this location if the parameter has been specified after terraform plan runs. 

Many Thanks,
Tyler Allen