### PR TITLE
Added sovereign cloud support

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -497,11 +497,46 @@ function set_arm_tenant_id_user_assigned_client {
     fi
 }
 
+function export_azure_cloud_env {
+    local tf_cloud_env=''
+
+    unset AZURE_ENVIRONMENT
+    unset ARM_ENVIRONMENT
+    export AZURE_ENVIRONMENT=$(az cloud show --query name -o tsv)
+
+    if [ -z "$cloud_name" ]; then
+
+        case $AZURE_ENVIRONMENT in
+            AzureCloud)
+            tf_cloud_env='public'
+            ;;
+            AzureChinaCloud)
+            tf_cloud_env='china'
+            ;;
+            AzureUSGovernment)
+            tf_cloud_env='usgovernment'
+            ;;
+            AzureGermanCloud)
+            tf_cloud_env='german'
+            ;;
+        esac
+
+        export ARM_ENVIRONMENT=$tf_cloud_env
+    else
+        export ARM_ENVIRONMENT=$cloud_name
+    fi
+
+    echo " - AZURE_ENVIRONMENT: ${AZURE_ENVIRONMENT}"
+    echo " - ARM_ENVIRONMENT: ${ARM_ENVIRONMENT}"
+}
+
 function get_logged_user_object_id {
     echo "@calling_get_logged_user_object_id"
 
     export TF_VAR_user_type=$(az account show \
         --query user.type -o tsv)
+
+    export_azure_cloud_env
 
     if [ ${TF_VAR_user_type} == "user" ]; then
 

--- a/scripts/rover.sh
+++ b/scripts/rover.sh
@@ -42,6 +42,10 @@ while (( "$#" )); do
             export TF_VAR_tf_name=${TF_VAR_tf_name:="$(basename ${landingzone_name}).tfstate"}
             shift 2
             ;;
+        -c|--cloud)
+            export cloud_name=${2}
+            shift 2
+            ;;
         -a|--action)
             export tf_action=${2}
             shift 2


### PR DESCRIPTION
**Changes:**
* Added sovereign cloud support.
* Added custom rover argument to set cloud name. This is for Azure Stack.

**Sample:**
```
rover -lz /tf/caf/public/landingzones/landingzones/caf_launchpad \
  -launchpad \
  -var-folder /tf/caf/public/config/configuration/${environment}/level0/launchpad \
  -parallelism 30 \
  -level level0 \
  -env ${environment} \
  -a [plan|apply|destroy]
  -c azure_stack
```

**Issue Details:**

In order to use rover in sovereign clouds, extra ARM environment variables must be exported so that Terraform uses the appropriate endpoints.

Environment variables to export:
```
ARM_ENVIRONMENT=<tf cloud environment name>
AZURE_ENVIRONMENT=<az cloud environment name>
```

Terraform environments:
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#environment

Azure environments:
https://docs.microsoft.com/en-us/cli/azure/manage-clouds-azure-cli