### PR TITLE
CI: Added Verification of ci parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 version.txt
 landingzones
 public/
+.data

--- a/.shellspec
+++ b/.shellspec
@@ -1,0 +1,13 @@
+--shell bash
+--require spec_helper
+
+## Default kcov (coverage) options
+# --kcov-options "--include-path=. --path-strip-level=1"
+# --kcov-options "--include-pattern=.sh"
+# --kcov-options "--exclude-pattern=/.shellspec,/spec/,/coverage/,/report/"
+
+## Example: Include script "myprog" with no extension
+# --kcov-options "--include-pattern=.sh,scripts"
+
+## Example: Only specified files/directories
+# --kcov-options "--include-pattern=scripts,/lib/"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
-source ./task.sh
+source /tf/rover/task.sh
 
 declare -a CI_TASK_CONFIG_FILE_LIST=()
 declare -a REGISTERED_CI_TASKS=()
-declare CI_TASK_DIR=./ci_tasks/
+declare CI_TASK_DIR=/tf/rover/ci_tasks/
 
 function verify_ci_parameters {
     echo "@Verifying ci parameters"
-    # Hattan
-    # verify symphony yaml file path
+    
+    if [ -z "$symphony_yml_path" ]; then        
+        export code="1"
+        error "1" "Missing path to symphony.yml. Please provide a path to the file via -sc or--symphony-config" 
+        echo "here!"
+    fi
+
     # verify ci task configs
     # if running single task, verify that task name is valid
 }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -6,17 +6,38 @@ declare -a CI_TASK_CONFIG_FILE_LIST=()
 declare -a REGISTERED_CI_TASKS=()
 declare CI_TASK_DIR=/tf/rover/ci_tasks/
 
+function verify_task_name(){
+    local ci_task_name=$1
+    local isTaskNameRegistered=$(task_is_registered "$ci_task_name")
+    if [ "$isTaskNameRegistered" != "true" ]; then        
+        export code="1"
+        error "1" "$ci_task_name is not a registered ci command!" 
+        return $code
+    fi     
+}
+
 function verify_ci_parameters {
     echo "@Verifying ci parameters"
-    
+
+    # verify symphony yaml
     if [ -z "$symphony_yml_path" ]; then        
         export code="1"
         error "1" "Missing path to symphony.yml. Please provide a path to the file via -sc or--symphony-config" 
-        echo "here!"
+        return $code
     fi
 
+    if [ ! -f "$symphony_yml_path" ]; then        
+        export code="1"
+        error "1" "Invalid path, $symphony_yml_path file not found. Please provide a valid path to the file via -sc or--symphony-config" 
+        return $code
+    fi    
+
     # verify ci task configs
-    # if running single task, verify that task name is valid
+    verify_task_name "terraform-format"
+    verify_task_name "tflint"
+    if [ ! -z "$ci_task_name" ]; then
+        verify_task_name "$ci_task_name"    
+    fi    
 }
 
 function set_default_parameters {
@@ -44,13 +65,14 @@ function register_ci_tasks {
 
 function task_is_registered {
   local task_name=$1
-  for task in $REGISTERED_CI_TASKS
-  do
-    if [ $task eq $task_name ]; then
-      return 1
+  for task in "${REGISTERED_CI_TASKS[@]}"
+  do    
+    if [ "$task" == "$task_name" ]; then
+      echo "true"
+      return
     fi
   done
-  return 0
+  echo "false"
 }
 
 function execute_ci_actions {

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,5 +1,4 @@
-source /tf/rover/ci.sh
-source /tf/rover/symphony_yaml.sh
+
 
 error() {
     local parent_lineno="$1"
@@ -88,8 +87,8 @@ function process_actions {
             deploy_tfc ${TF_VAR_workspace}
             ;;
         ci)
-            register_ci_tasks
             verify_ci_parameters
+            register_ci_tasks            
             set_default_parameters
             execute_ci_actions
             ;;

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -87,8 +87,8 @@ function process_actions {
             deploy_tfc ${TF_VAR_workspace}
             ;;
         ci)
-            verify_ci_parameters
-            register_ci_tasks            
+            register_ci_tasks  
+            verify_ci_parameters                      
             set_default_parameters
             execute_ci_actions
             ;;

--- a/scripts/rover.sh
+++ b/scripts/rover.sh
@@ -10,6 +10,10 @@ source /tf/rover/functions.sh
 source /tf/rover/tfstate_azurerm.sh
 source /tf/rover/banner.sh
 
+# symphony
+source /tf/rover/ci.sh
+source /tf/rover/symphony_yaml.sh
+
 export ROVER_RUNNER=${ROVER_RUNNER:=false}
 
 verify_rover_version

--- a/spec/harness/symphony.yml
+++ b/spec/harness/symphony.yml
@@ -1,0 +1,61 @@
+environment: prod
+repositories:
+  - name: launchpad_lz
+    uri: <url>:reference_app_caf/caf_modules_public.git
+    branch: master
+  - name: launchpad_config
+    uri: <url>:reference_app_caf/base_config.git
+    branch: master
+  - name: solution_lz
+    uri: <url>:reference_app_caf/caf_modules_app.git
+    branch: master
+  - name: solution_aks_config
+    uri: <url>:reference_app_caf/app_config_aks.git
+    branch: master
+  - name: argocd_config
+    uri: <url>:reference_app_caf/app_config_argocd.git
+    branch: master
+
+ # All paths are relative
+levels:
+- level: level0
+  type: platform
+  stacks:
+  - stack: launchpad
+    landingZonePath: caf_modules_public/landingzones/caf_launchpad/
+    configurationPath: base_config/level0/
+  launchpad: true
+
+- level: level1
+  type: platform
+  stacks:
+  - stack: foundations
+    landingZonePath: caf_modules_public/landingzones/caf_foundations/
+    configurationPath: base_config/level1
+    tfState: foundations.tfstate
+
+- level: level2
+  stacks:
+  - stack: networking_hub
+    landingZonePath: caf_modules_public/landingzones/caf_networking/
+    configurationPath: base_config/level2/networking/hub/
+    tfState: networking_hub.tfstate
+    
+  - stack: shared_services
+    landingZonePath: caf_modules_public/landingzones/caf_shared_services/
+    configurationPath: base_config/level2/shared_services/
+    tfState: caf_shared_services.tfstate
+
+- level: level3
+  stacks:
+  - stack: catalog_service
+    landingZonePath: caf_modules_app/landingzones/caf_solutions/
+    configurationPath: app_config_aks/level3/
+    tfState: landingzone_aks.tfstate
+
+- level: level4
+  stacks:
+  - stack: catalog_service_application
+    landingZonePath: caf_modules_app/landingzones/caf_solutions/add-ons/aks_applications/
+    configurationPath: app_config_argocd/level4/argocd/
+    tfState: argocd.tfstate

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,0 +1,24 @@
+# shellcheck shell=sh
+
+# Defining variables and functions here will affect all specfiles.
+# Change shell options inside a function may cause different behavior,
+# so it is better to set them here.
+# set -eu
+
+# This callback function will be invoked only once before loading specfiles.
+spec_helper_precheck() {
+  # Available functions: info, warn, error, abort, setenv, unsetenv
+  # Available variables: VERSION, SHELL_TYPE, SHELL_VERSION
+  : minimum_version "0.28.1"
+}
+
+# This callback function will be invoked after a specfile has been loaded.
+spec_helper_loaded() {
+  :
+}
+
+# This callback function will be invoked after core modules has been loaded.
+spec_helper_configure() {
+  # Available functions: import, before_each, after_each, before_all, after_all
+  : import 'support/custom_matcher'
+}

--- a/spec/unit/ci_spec.sh
+++ b/spec/unit/ci_spec.sh
@@ -1,0 +1,77 @@
+Describe 'ci.sh'
+  Include scripts/ci.sh
+  Describe "verify_ci_parameters"
+    #Function Mocks
+    error() {
+        local parent_lineno="$1"
+        local message="$2"
+        >&2 echo "Error line:${parent_lineno}: message:${message} status :${code}"
+        return ${code}
+    }    
+
+    Context "No Symphony Yaml Provided"
+      setup() { 
+        unset symphony_yml_path
+      }
+      BeforeEach 'setup'
+
+      It 'should return an error that the path to symphony.yml is not provided'
+        When call verify_ci_parameters
+        The output should eq '@Verifying ci parameters'
+        The error should eq 'Error line:1: message:Missing path to symphony.yml. Please provide a path to the file via -sc or--symphony-config status :1'
+        The status should eq 1    
+      End
+    End 
+
+    Context "Symphony Yaml Provided, invalid file"
+      setup() { 
+        export symphony_yml_path="spec/harness/symphony2.yml"
+      }
+      BeforeEach 'setup'
+
+      It 'should return an error if the symphony yaml path points to an invalid or missing file'
+        When call verify_ci_parameters
+        The output should eq '@Verifying ci parameters'
+        The error should eq 'Error line:1: message:Invalid path, spec/harness/symphony2.yml file not found. Please provide a valid path to the file via -sc or--symphony-config status :1'
+        The status should eq 1
+      End
+    End 
+
+
+    Context "Symphony Yaml Provided, valid file"
+      Describe "tasks registered"
+        setup() { 
+          register_ci_tasks > /dev/null 2>&1
+          export symphony_yml_path="spec/harness/symphony.yml"
+        }
+        Before 'setup'
+  
+        It 'should return no errors if symphony yaml is valid and ci tasks are registered'
+          When call verify_ci_parameters
+          The output should eq '@Verifying ci parameters'
+          The status should eq 0
+        End
+      End
+
+      Describe "no tasks registered"
+        setup() { 
+          CI_TASK_CONFIG_FILE_LIST=()
+          REGISTERED_CI_TASKS=()
+          export symphony_yml_path="spec/harness/symphony.yml"
+        }
+        Before 'setup'
+  
+        It 'should return no errors if symphony yaml is valid and ci tasks are registered'
+          When call verify_ci_parameters
+          The error should eq 'Error line:1: message:terraform-format is not a registered ci command! status :1
+Error line:1: message:tflint is not a registered ci command! status :1'
+          The output should eq '@Verifying ci parameters'
+          The status should eq 0
+        End
+      End
+      
+    End 
+
+
+  End    
+End


### PR DESCRIPTION
Added verification support for ci parameters & shellspec tests.

* Used full rover path for sourcing (/tf/rover) instead of relative. This allows rover to work in any path.
* Moved sourcing declaration out of ci.sh and into rover.sh as it's the main entry point for the script.
* Added sample symphony.yml as a test harness for shellspec specs.