### PR TITLE
Add soveregin cloud endpoints and suffix environment variables (part 1)

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -529,6 +529,7 @@ function set_arm_tenant_id_user_assigned_client {
 function export_azure_cloud_env {
     local tf_cloud_env=''
 
+    # Set cloud variables for terraform
     unset AZURE_ENVIRONMENT
     unset ARM_ENVIRONMENT
     export AZURE_ENVIRONMENT=$(az cloud show --query name -o tsv)
@@ -557,6 +558,13 @@ function export_azure_cloud_env {
 
     echo " - AZURE_ENVIRONMENT: ${AZURE_ENVIRONMENT}"
     echo " - ARM_ENVIRONMENT: ${ARM_ENVIRONMENT}"
+    
+    # Set landingzone cloud variables for modules
+    echo "Initalizing az cloud variables"
+    while IFS="=" read key value; do
+        echo " - TF_VAR_$key = $value"
+        export "TF_VAR_$key=$value"
+    done < <(az cloud show | jq -r ".suffixes * .endpoints|to_entries|map(\"\(.key)=\(.value)\")|.[]")
 }
 
 function get_logged_user_object_id {


### PR DESCRIPTION
This PR resolves part one of the bug issue. See issue for other parts.

Update to export_azure_cloud_env
- Retrieve az cloud show endpoints and suffixes
- Exports key and values to shell environment

closes #155