### PR TITLE
Add support for Rover test

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -118,6 +118,10 @@ function process_actions {
             set_default_parameters
             execute_ci_actions
             ;;
+
+        test)
+            run_integration_tests
+            ;;
         *)
             display_instructions
     esac

--- a/scripts/rover.sh
+++ b/scripts/rover.sh
@@ -13,6 +13,7 @@ source /tf/rover/banner.sh
 # symphony
 source /tf/rover/ci.sh
 source /tf/rover/symphony_yaml.sh
+source /tf/rover/test_runner.sh
 
 export ROVER_RUNNER=${ROVER_RUNNER:=false}
 
@@ -86,6 +87,11 @@ while (( "$#" )); do
             export caf_command="ci"
             export devops="true"
             ;;
+        test)
+            shift 1
+            export caf_command="test"
+            export devops="true"
+            ;;            
         cd)
             shift 1
             export caf_command="cd"

--- a/scripts/test_runner.sh
+++ b/scripts/test_runner.sh
@@ -44,9 +44,3 @@ find_and_export_prefix () {
   echo $prefix
 }
 
-rover test \
-      -b /home/hattan/projects/caf/symphony/tests \
-      -env one_week \
-      -level level0 \
-      -tfstate caf_launchpad.tfstate \
-      -d 

--- a/scripts/test_runner.sh
+++ b/scripts/test_runner.sh
@@ -4,26 +4,23 @@ function run_integration_tests {
   information @"Run Integration Tests"
 
   get_storage_id
-  download_tfstate
+  download_tfstate 
 
   mv "${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/$TF_VAR_tf_name" "${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/terraform.tfstate"
   local prefix=$(find_and_export_prefix)
   export STATE_FILE_PATH="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}"
-  
-  debug "  Test Directory   : $base_directory"
-  debug "  Environment      : $TF_VAR_environment"
-  debug "  STATE_FILE_PATH  : $STATE_FILE_PATH"
-  debug "  Level            : $TF_VAR_level"
-  debug "  Prefix           : $prefix"
-  
   export PREFIX=$prefix
   export ENVIRONMENT=$TF_VAR_environment
-  export STATE_FILE_PATH="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}"
   
-  cd $base_directory 
-    pwd
-    go test
-  cd -
+  debug "  Test Directory   : $base_directory"
+  debug "  Environment      : $ENVIRONMENT"
+  debug "  STATE_FILE_PATH  : $STATE_FILE_PATH"
+  debug "  Level            : $TF_VAR_level"
+  debug "  Prefix           : $PREFIX"
+   
+  pushd $base_directory > /dev/null
+    go test 
+  popd
 }
 
 find_and_export_prefix () {
@@ -33,10 +30,3 @@ find_and_export_prefix () {
 
   echo $prefix
 }
-
-# rover test \
-#       -b ~/projects/caf/symphony/tests \
-#       -env one_week \
-#       -level level0 \
-#       -tfstate caf_launchpad.tfstate \
-#       -d 

--- a/scripts/test_runner.sh
+++ b/scripts/test_runner.sh
@@ -3,10 +3,16 @@
 function run_integration_tests {
   information @"Run Integration Tests"
 
+  if [ ! -x "$(command -v go)" ]; then
+    error "go is not installed and is a required dependency to run integration tests."
+    
+  fi  
+
   get_storage_id
   download_tfstate 
 
-  mv "${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/$TF_VAR_tf_name" "${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/terraform.tfstate"
+  local targetStateFile="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/terraform.tfstate"
+  mv "${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/$TF_VAR_tf_name" $targetStateFile
   local prefix=$(find_and_export_prefix)
   export STATE_FILE_PATH="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}"
   export PREFIX=$prefix
@@ -15,12 +21,16 @@ function run_integration_tests {
   debug "  Test Directory   : $base_directory"
   debug "  Environment      : $ENVIRONMENT"
   debug "  STATE_FILE_PATH  : $STATE_FILE_PATH"
+  debug "  STATE_FILE       : $targetStateFile"
   debug "  Level            : $TF_VAR_level"
   debug "  Prefix           : $PREFIX"
    
   pushd $base_directory > /dev/null
-    go test 
-  popd
+    go test -v -tags $TF_VAR_level
+  popd > /dev/null
+
+  debug "Removing $targetStateFile"
+  rm $targetStateFile
 }
 
 find_and_export_prefix () {
@@ -30,3 +40,10 @@ find_and_export_prefix () {
 
   echo $prefix
 }
+
+rover test \
+      -b /home/hattan/projects/caf/symphony/tests \
+      -env one_week \
+      -level level0 \
+      -tfstate caf_launchpad.tfstate \
+      -d 

--- a/scripts/test_runner.sh
+++ b/scripts/test_runner.sh
@@ -5,7 +5,10 @@ function run_integration_tests {
 
   if [ ! -x "$(command -v go)" ]; then
     error "go is not installed and is a required dependency to run integration tests."
-    
+  fi  
+
+  if [[ ! -d $base_directory ]]; then
+    error "Integration test path is invalid. $base_directory is not a valid path."
   fi  
 
   get_storage_id

--- a/scripts/test_runner.sh
+++ b/scripts/test_runner.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+function run_integration_tests {
+  information @"Run Integration Tests"
+
+  get_storage_id
+  download_tfstate
+
+  mv "${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/$TF_VAR_tf_name" "${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/terraform.tfstate"
+  local prefix=$(find_and_export_prefix)
+  export STATE_FILE_PATH="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}"
+  
+  debug "  Test Directory   : $base_directory"
+  debug "  Environment      : $TF_VAR_environment"
+  debug "  STATE_FILE_PATH  : $STATE_FILE_PATH"
+  debug "  Level            : $TF_VAR_level"
+  debug "  Prefix           : $prefix"
+  
+  export PREFIX=$prefix
+  export ENVIRONMENT=$TF_VAR_environment
+  export STATE_FILE_PATH="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}"
+  
+  cd $base_directory 
+    pwd
+    go test
+  cd -
+}
+
+find_and_export_prefix () {
+  rgName=$(az group list --query "[?tags.environment=='$TF_VAR_environment' && tags.landingzone].{Name:name}" | jq -r "first(.[].Name)")
+
+  prefix=${rgName%-rg-launchpad*}
+
+  echo $prefix
+}
+
+# rover test \
+#       -b ~/projects/caf/symphony/tests \
+#       -env one_week \
+#       -level level0 \
+#       -tfstate caf_launchpad.tfstate \
+#       -d 

--- a/scripts/tfstate_azurerm.sh
+++ b/scripts/tfstate_azurerm.sh
@@ -100,7 +100,7 @@ function upload_tfstate {
 function download_tfstate {
     echo "@calling download_tfstate"
 
-    echo "Downloading Remote state from to the cloud"
+    echo "Downloading Remote state from the cloud"
 
     stg=$(az storage account show --ids ${id} -o json)
     stg_name=$(az storage account show --ids ${id} -o json | jq -r .name)

--- a/scripts/tfstate_azurerm.sh
+++ b/scripts/tfstate_azurerm.sh
@@ -97,6 +97,33 @@ function upload_tfstate {
 
 }
 
+function download_tfstate {
+    echo "@calling download_tfstate"
+
+    echo "Downloading Remote state from to the cloud"
+
+    stg=$(az storage account show --ids ${id} -o json)
+    stg_name=$(az storage account show --ids ${id} -o json | jq -r .name)
+    export storage_account_name=$(echo ${stg} | jq -r .name) && echo " - storage_account_name: ${storage_account_name}"
+    export resource_group=$(echo ${stg} | jq -r .resourceGroup) && echo " - resource_group: ${resource_group}"
+    export access_key=$(az storage account keys list --subscription ${TF_VAR_tfstate_subscription_id} --account-name ${storage_account_name} --resource-group ${resource_group} -o json | jq -r .[0].value) && echo " - storage_key: retrieved"
+
+    az storage blob download \
+        --subscription ${TF_VAR_tfstate_subscription_id} \
+        --name ${TF_VAR_tf_name} \
+        --file "${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_name}" \
+        --container-name ${TF_VAR_workspace} \
+        --auth-mode "key" \
+        --account-name ${stg_name} \
+        --account-key ${access_key} \
+        --no-progress
+
+    RETURN_CODE=$?
+    if [ $RETURN_CODE != 0 ]; then
+        error ${LINENO} "Error Downloading the blob storage" $RETURN_CODE
+    fi
+}
+
 function deploy_from_remote_state {
     echo "@calling deploy_from_remote_state"
 


### PR DESCRIPTION
This PR introduce a rover test command. Rover test allows you to execute terratest integration tests against a deployed CAF environment. 

The workflow would be to first deploy and environment then can rover test with the following options:

```shell
rover test \
      -b <path to test folder> \
      -env <environment name> \
      -level <level> \
      -tfstate <state file> \
      -d 
```

In order to run test all the above parameters must be supplied including level, environment and state file name. 

It's also expected that the tests use [go build tags](https://wawand.co/blog/posts/using-build-tags/) with the following tags:
* level0
* level1
* level2
* level3
* level4

For example tests, please see: https://github.com/aztfmod/symphony/blob/rover_test/tests/level0_test.go

The example tests above use local state in order to verify that the resources were deployed correctly to azure. To facilitate this, rover test downloads the state file and renames it to terraform.tfstate (needed by terratest) then removes the state file after test execution.