### PR TITLE
Fix extract rover version from a docker image

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -729,7 +729,7 @@ function verify_rover_version {
     user=$(whoami)
 
     if [ "${ROVER_RUNNER}" = false ]; then
-        required_version=$(cat /tf/caf/.devcontainer/docker-compose.yml | yq | jq -r '.services | first(.[]).image' | awk -F'/' '{print $2}')
+        required_version=$(cat /tf/caf/.devcontainer/docker-compose.yml | yq | jq -r '.services | first(.[]).image' | awk -F'/' '{print $NF}')
         running_version=$(cat /tf/rover/version.txt | awk -F'/' '{print $2}')
 
         if [ "${required_version}" != "${running_version}" ]; then


### PR DESCRIPTION
If a docker image of the rover pulls from a custom Docker registry, the verify_rover_version function will always fail.

Example: `docker.artifactory.internal/aztfmod/rover:0.15.4-xxx`