### PR TITLE
Fixing bug with rover cd and adding caflint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV SSH_PASSWD=${SSH_PASSWD} \
     versionCheckov=${versionCheckov} \
     versionMssqlTools=${versionMssqlTools} \
     versionTerraformDocs=${versionTerraformDocs} \
-    PATH="${PATH}:/opt/mssql-tools/bin" \
+    PATH="${PATH}:/opt/mssql-tools/bin:/home/vscode/.local/lib/shellspec/bin:/home/vscode/go/bin" \
     TF_DATA_DIR="/home/${USERNAME}/.terraform.cache" \
     TF_PLUGIN_CACHE_DIR="/home/${USERNAME}/.terraform.cache/plugin-cache" \
     LANG=en_US.UTF-8 \
@@ -282,6 +282,7 @@ COPY ./scripts/walkthrough.sh .
 COPY ./scripts/sshd.sh .
 COPY ./scripts/backend.hcl.tf .
 COPY ./scripts/ci.sh .
+COPY ./scripts/cd.sh .
 COPY ./scripts/task.sh .
 COPY ./scripts/symphony_yaml.sh .
 COPY ./scripts/test_runner.sh .
@@ -353,5 +354,10 @@ RUN echo "Installing Tflint Ruleset ${versionTflintazrs} for Azure..." && \
     rm /tmp/tflint-ruleset-azurerm.zip
 
 RUN echo "Installing shellspec..." && \
-    curl -fsSL https://git.io/shellspec | sh -s -- --yes && \
-    export PATH=$PATH:/home/vscode/.local/lib/shellspec/bin
+    curl -fsSL https://git.io/shellspec | sh -s -- --yes 
+
+
+RUN echo "Installing caflint..." && \
+    go install github.com/aztfmod/caflint@latest 
+
+

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -126,7 +126,7 @@ function build_rover_agents {
 
 echo "Building rover images."
 if [ "$strategy" == "ci" ]; then
-    build_base_rover_image "0.13.6" ${strategy}
+    build_base_rover_image "1.0.0" ${strategy}
 else
     while read versionTerraform; do
         build_base_rover_image ${versionTerraform} ${strategy}


### PR DESCRIPTION
This PR fixes the following:

*  Adds missing cd.sh file to dockerfile copy. This is used by docker deploy.
* Adds caflint cli tool
* Adds ~/go/bin to path
* Adds shellspec bin to path