### PR TITLE
Added bsdmainutils for column usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See http://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: git://github.com/IamTheFij/docker-pre-commit
-    rev: v2.0.0
+    rev: v2.0.1
     hooks:
     - id: docker-compose-check
   - repo: git://github.com/pre-commit/pre-commit-hooks

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,8 @@ RUN apt-get update && \
     vim \
     gpg \
     apt-utils \
-    gpg-agent && \
+    gpg-agent \
+    bsdmainutils && \
     #
     # Create USERNAME
     #


### PR DESCRIPTION
The `column` utility is missing causing the `rover landingzone list -level level0 -env production` command to fail within the function `list_deployed_landingzones` with:

```
@calling list_deployed_landingzones
 - storage_account_name: sttfstatelevel0prd

Landing zones deployed:

/tf/rover/functions.sh: line 305: column: command not found
Error on or near line 305; exiting with status 1
```

After adding the `bsdmainutils` package, containing `column`  the  `rover landingzone list -level level0 -env Production`  command succeeds:

```
@calling list_deployed_landingzones
 - storage_account_name: sttfstatelevel0prd

Landing zones deployed:

"landing zone"           "size in Kb"  "last modification"
"caf_launchpad.tfstate"  5331.58       "2021-01-01T00:00:00+00:00"
```
