### PR TITLE
Fix conditionals in get_storage_id

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -436,11 +436,6 @@ function workspace {
     echo "@calling workspace function with $@"
     get_storage_id
 
-    if [ "${id}" == "null" ]; then
-        display_launchpad_instructions
-        exit 1000
-    fi
-
     case "${1}" in
     "list")
         workspace_list

--- a/scripts/tfstate_azurerm.sh
+++ b/scripts/tfstate_azurerm.sh
@@ -557,13 +557,13 @@ function get_storage_id {
         --subscription ${TF_VAR_tfstate_subscription_id} \
         --query "[?tags.tfstate=='${TF_VAR_level}' && tags.environment=='${TF_VAR_environment}'].{id:id}[0]" -o json | jq -r .id)
 
-    if [[ ${id} == null ]] && [ "${caf_command}" != "launchpad" ]; then
+    if [[ -z ${id} ]] && [ "${caf_command}" != "launchpad" ]; then
         # Check if other launchpad are installed
         id=$(execute_with_backoff az storage account list \
             --subscription ${TF_VAR_tfstate_subscription_id} \
             --query "[?tags.tfstate=='${TF_VAR_level}'].{id:id}[0]" -o json | jq -r .id)
 
-        if [ ${id} == null ]; then
+        if [[ -z ${id} ]]; then
             if [ ${TF_VAR_level} != "level0" ]; then
                 echo "You need to initialize that level first before using it or you do not have permission to that level."
             else


### PR DESCRIPTION
The checks for missing storage account ids would never fire as 'null' is
not a valid type in bash.

This resulted in an empty value for 'ids' being returned causing
subsequent errors in the 'az' command (and possibly elsewhere).

Update these to the standard bash '-z' check. Also remove the check for
null in functions.sh as this case is covered within get_storage_id.

Fixes aztfmod/rover/issues/207