### PR TITLE
declare tf_plan_file as local in terraform functions

### DIFF
--- a/scripts/tfstate_azurerm.sh
+++ b/scripts/tfstate_azurerm.sh
@@ -304,7 +304,7 @@ function apply {
         echo "Plan not provided with -p or --plan so calling terraform plan"
         plan
 
-        tf_plan_file="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_plan}"
+        local tf_plan_file="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_plan}"
     fi
 
     echo "Running Terraform apply with plan ${tf_plan_file}"
@@ -399,7 +399,7 @@ function destroy {
             echo "Plan not provided with -p or --plan so calling terraform plan"
             plan "-destroy"
 
-            tf_plan_file="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_plan}"
+            local tf_plan_file="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_plan}"
         fi
 
         RETURN_CODE=$? && echo "Line ${LINENO} - Terraform init return code ${RETURN_CODE}"
@@ -461,7 +461,7 @@ function destroy {
             echo "Plan not provided with -p or --plan so calling terraform plan"
             plan "-destroy"
 
-            tf_plan_file="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_plan}"
+            local tf_plan_file="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_plan}"
         fi
 
         echo "using tfstate from ${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_name}"


### PR DESCRIPTION
Closes: #221 

The tf_plan_file variable should be declared as local, otherwise, when using rover deploy with symphony, the tf_plan_file variable is carried between landing zone execution and successive executions will use that plan file instead of creating a new one.