### PR TITLE
Add support for 'terraform show'

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -751,7 +751,7 @@ function deploy {
                 "destroy")
                     destroy_from_remote_state
                     ;;
-                "plan"|"apply"|"validate"|"refresh"|"graph"|"import"|"output"|"taint"|"untaint"|"state list"|"state rm"|"state show")
+                "plan"|"apply"|"validate"|"refresh"|"graph"|"import"|"output"|"taint"|"untaint"|"state list"|"state rm"|"state show"|"show")
                     deploy_from_remote_state
                     ;;
                 *)

--- a/scripts/rover.sh
+++ b/scripts/rover.sh
@@ -261,7 +261,7 @@ case "${caf_command}" in
     launchpad|landingzone)
         if [[ ("${tf_action}" == "destroy") && (${var_folder_set} == true) && ( ! -z "${tf_plan_file}" ) ]]; then
             error ${LINENO} "-var-folder or -var-file must not be set when using a plan in the destroy operation." 1
-        elif [[ ("${tf_action}" != "destroy") && (-z "${tf_command}") ]]; then
+        elif [[ ("${tf_action}" != "destroy" && "${tf_action}" != "show") && (-z "${tf_command}") ]]; then
             error ${LINENO} "No parameters have been set in ${caf_command}." 1
         fi
         ;;

--- a/scripts/tfstate_azurerm.sh
+++ b/scripts/tfstate_azurerm.sh
@@ -529,13 +529,15 @@ function destroy {
 function other {
     echo "@calling other"
 
-    echo "running terraform ${tf_action} -state="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_name}"  ${tf_command}"
+    echo "running terraform ${tf_action} ${tf_command}"
 
     rm -f $STDERR_FILE
 
-    terraform ${tf_action} \
-        -state="${TF_DATA_DIR}/tfstates/${TF_VAR_level}/${TF_VAR_workspace}/${TF_VAR_tf_name}" \
-        ${tf_command} 2>$STDERR_FILE | tee ${tf_output_file}
+    if [[ -z ${tf_plan_file} ]]; then
+      terraform ${tf_action} ${tf_command} 2>$STDERR_FILE | tee ${tf_output_file}
+    else
+      terraform ${tf_action} ${tf_command} ${tf_plan_file} 2>$STDERR_FILE | tee ${tf_output_file}
+    fi
 
     RETURN_CODE=${PIPESTATUS[0]} && echo "Terraform ${tf_action} return code: ${RETURN_CODE}"
 


### PR DESCRIPTION
Example usage:

Show current state:
```
/tf/rover/rover.sh \
  -lz /tf/caf/landingzones/caf-terraform-landingzones/caf_solution/ \
  -level level3 \
  -tfstate aks.tfstate \
  -env foo \
  -a show [-json]
```

Show a plan file:
```
/tf/rover/rover.sh \
  -lz /tf/caf/landingzones/caf-terraform-landingzones/caf_solution/ \
  -level level3 \
  -tfstate aks.tfstate \
  -env foo \
  -a show [-json] /tmp/out.plan
```

Implements https://github.com/aztfmod/rover/issues/181