### PR TITLE
fix terraform state subcommands

### DIFF
--- a/scripts/rover.sh
+++ b/scripts/rover.sh
@@ -86,7 +86,7 @@ while (( "$#" )); do
            shift 2
            ;;
         -a|--action)
-            export tf_action=$(parameter_value --action ${2})
+            export tf_action=$(parameter_value --action "${2}")
             shift 2
             ;;
         --clone-launchpad)
@@ -269,7 +269,7 @@ case "${caf_command}" in
     launchpad|landingzone)
         if [[ ("${tf_action}" == "destroy") && (${var_folder_set} == true) && ( ! -z "${tf_plan_file}" ) ]]; then
             error ${LINENO} "-var-folder or -var-file must not be set when using a plan in the destroy operation." 1
-        elif [[ ("${tf_action}" != "destroy") && (-z "${tf_command}") ]]; then
+        elif [[ ("${tf_action}" != "destroy") && !("${tf_action}" =~  ^state ) && (-z "${tf_command}") ]]; then
             error ${LINENO} "No parameters have been set in ${caf_command}." 1
         fi
         ;;


### PR DESCRIPTION
- Internally quote subcommand, otherwise 'state list' is chopped into state
- Don't look for var-file or var-folder when running state commands

Thank you