### PR TITLE
Exit with error if no launchpad found

### DIFF
--- a/scripts/tfstate.sh
+++ b/scripts/tfstate.sh
@@ -682,7 +682,7 @@ function get_storage_id {
                 --subscription ${TF_VAR_tfstate_subscription_id} \
                 --query "[?tags.tfstate=='${TF_VAR_level}'].{name:name,environment:tags.environment, launchpad:tags.launchpad}" -o table
 
-            exit 0
+            exit 1
         fi
     fi
 }


### PR DESCRIPTION
In the case where no matching environment is found or the user doesn't
have enough permissions, we should exit with non zero. An example use
case is where I mistype or otherwise forget to set my environment, rover
will output the "There is no remote state for ..." message, but in a
pipeline can look like it has passed.