### PR TITLE
Do not configure remote backend for launchpad

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -695,7 +695,9 @@ function deploy {
             migrate
             ;;
         *)
-            tfstate_configure ${gitops_terraform_backend_type}
+            if [ "${caf_command}" != "launchpad" ]; then
+                tfstate_configure ${gitops_terraform_backend_type}
+            fi
 
             if [ "${gitops_terraform_backend_type}" = "azurerm" ]; then
                 deploy_azurerm


### PR DESCRIPTION
When using azurerm backend type remote backend must not be enabled as rover will use a local state and move it to azurerm once completed