### PR TITLE
Updated Impersonate function to fix a breaking change.

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -296,7 +296,6 @@ function login_as_sp_from_keyvault_secrets {
 
     information "Login with service principal"
     az login --service-principal -u ${ARM_CLIENT_ID} -p ${ARM_CLIENT_SECRET} -t ${ARM_TENANT_ID}  --only-show-errors 1> /dev/null
-    az account set -s ${target_subscription}
 
     set +e
     trap - ERR


### PR DESCRIPTION
Issue: https://github.com/aztfmod/rover/issues/267

Removed the redundant 'az account set' after az login in function
'login_as_sp_from_keyvault_secrets' in functions.sh to fix the
bug #267