### PR TITLE
Add bootstraps command variations

### DIFF
--- a/scripts/lib/bootstrap.sh
+++ b/scripts/lib/bootstrap.sh
@@ -21,13 +21,16 @@ bootstrap() {
     create_federated_identity ${aad_app_name}
   fi
 
-  process_gitops_agent_pool ${gitops_agent_pool_type}
+  if [ ! -z ${gitops_pipelines} ]; then
+    process_gitops_agent_pool ${gitops_agent_pool_type}
+  fi
 
   if [ ! -z ${bootstrap_script} ]; then
     register_rover_context
-    ${bootstrap_script} "topology_file=${caf_ignite_playbook}" "GITOPS_SERVER_URL=${GITOPS_SERVER_URL}" "RUNNER_NUMBERS=${gitops_number_runners}" "AGENT_TOKEN=${AGENT_TOKEN}" "gitops_agent=${gitops_agent_pool_type}" "ROVER_AGENT_DOCKER_IMAGE=${ROVER_AGENT_DOCKER_IMAGE}" "AZURE_OBJECT_ID=${app_object_id}" "subscription_deployment_mode=${subscription_deployment_mode}" "sub_management=${sub_management}" "sub_connectivity=${sub_connectivity}" "sub_identity=${sub_identity}" "sub_security=${sub_security}"
+    ${bootstrap_script} "topology_file=${caf_ignite_playbook}" "GITOPS_SERVER_URL=${GITOPS_SERVER_URL}" "RUNNER_NUMBERS=${gitops_number_runners}" "AGENT_TOKEN=${AGENT_TOKEN}" "gitops_agent=${gitops_agent_pool_type}" "ROVER_AGENT_DOCKER_IMAGE=${ROVER_AGENT_DOCKER_IMAGE}" "AZURE_OBJECT_ID=${app_object_id}" "subscription_deployment_mode=${subscription_deployment_mode}" "sub_management=${sub_management}" "sub_connectivity=${sub_connectivity}" "sub_identity=${sub_identity}" "sub_security=${sub_security}" "gitops_pipelines=${gitops_pipelines}"
   fi
 
+  information "Done."
 }
 
 assert_sessions() {
@@ -69,7 +72,7 @@ assert_gitops_session() {
 
 
 process_gitops_agent_pool() {
-  information "@call process_gitops_agent_pool"
+  information "@call process_gitops_agent_pool for ${1}"
 
   case "${1}" in
     "github")

--- a/scripts/rover.sh
+++ b/scripts/rover.sh
@@ -44,7 +44,6 @@ export TF_IN_AUTOMATION="true" #Overriden in logger if log-severity is passed in
 export TF_VAR_tf_cloud_organization=${TF_CLOUD_ORGANIZATION}
 export TF_VAR_tf_cloud_hostname=${TF_CLOUD_HOSTNAME:="app.terraform.io"}
 export REMOTE_credential_path_json=${REMOTE_credential_path_json:="$(echo ~)/.terraform.d/credentials.tfrc.json"}
-export gitops_pipelines="github"
 export gitops_terraform_backend_type=${TF_VAR_backend_type:="azurerm"}
 export gitops_agent_pool_type=${GITOPS_AGENT_POOL_TYPE:="github"}
 export gitops_agent_pool_name=${GITOPS_AGENT_POOL_NAME}


### PR DESCRIPTION

## Create only the azure AD application (global admin privilege)
```
az login --allow-no-subscriptions
org_name=contoso

rover -bootstrap \
  -aad-app-name ${org_name}-platform-landing-zones
```

## Create or Read (if no global admin privilege) and register the details as secret in Github
Will register the secrets to support OIDC connect from Github actions. 
```
az login
org_name=contoso

rover -bootstrap \
  -aad-app-name ${org_name}-platform-landing-zones \
  -gitops-pipelines github
```

## All in one

Create or check the Azure bootstrap app id exist
register the secrets for Github Actions deployment
Set the deployment mode to multi subscriptions
```
az login
org_name=contoso

rover -bootstrap \
  -aad-app-name ${org_name}-platform-landing-zones \
  -gitops-pipelines github \
  -gitops-number-runners 4 \
  -bootstrap-script '/tf/caf/landingzones/templates/platform/deploy_platform.sh' \
  -playbook '/tf/caf/landingzones/templates/platform/caf_platform_prod_nonprod.yaml' \
  -subscription-deployment-mode multi_subscriptions \
  -sub-management www-guid \
  -sub-connectivity xxx-guid \
  -sub-identity yyy-guid \
  -sub-security zzz-guid

```
