### PR TITLE
install az cli extension resource-graph

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -357,6 +357,12 @@ RUN echo  "Set rover version to ${versionRover}..." && echo "Installing Terrafor
     #
     echo  "Set rover version to ${versionRover}..." && \
     echo "${versionRover}" > /tf/rover/version.txt
+    
+#
+# Install az cli extensions
+#
+RUN echo "Installing az cli extension: resource-graph" && \
+    az extension add --name resource-graph --system
 
 
 COPY ./scripts/rover.sh ./scripts/tfstate.sh ./scripts/functions.sh ./scripts/remote.sh ./scripts/terraform-enterprise-push.sh ./scripts/parse_command.sh ./scripts/banner.sh ./scripts/clone.sh ./scripts/walkthrough.sh ./scripts/sshd.sh ./scripts/backend.hcl.tf ./scripts/backend.azurerm.tf ./scripts/ci.sh ./scripts/cd.sh ./scripts/task.sh ./scripts/symphony_yaml.sh ./scripts/test_runner.sh ./


### PR DESCRIPTION
To fix issue with missing resource-graph az cli extension.

![image](https://user-images.githubusercontent.com/88019935/181431512-73292ebb-905c-45b5-bc6b-41813b9e23aa.png)
