### PR TITLE
blinQ: Add support for -sub-sandbox. We need this because Sandbox is …

### DIFF
--- a/scripts/lib/parse_parameters.sh
+++ b/scripts/lib/parse_parameters.sh
@@ -276,6 +276,10 @@ parse_parameters() {
         export sub_security=${2}
         shift 2
         ;;
+      -sub-sandbox)
+        export sub_sandbox=${2}
+        shift 2
+        ;;
       -arm_use_oidc)
         export ARM_USE_OIDC=true
         shift 1


### PR DESCRIPTION
blinQ: Add support for -sub-sandbox. We need this because Sandbox is part of core landingzones in enterprise-scale module. We want to deploy core landingzones at level1/alz/es and need support to provide subscription_id during bootstrap process