### PR TITLE
Fix to run aztfmod examples with tfe

### DIFF
--- a/scripts/tfcloud/trigger_run_init.sh
+++ b/scripts/tfcloud/trigger_run_init.sh
@@ -139,7 +139,7 @@ tfcloud_trigger_run_init(){
   #
   # Each tfstates defined in the var.landingzone.tfstates or var.landingzone.remote_tfstates
   #
-  conf_lz=$(grep -rl "^landingzone = {" ${TF_var_folder}/*.tfvars)
+  conf_lz=$(grep -rl "^landingzone = {" ${TF_var_folder}/*.tfvars || true)
   if [ ! -z "$conf_lz" ]; then
     conf_lz_json=$(python3 ${script_path}/tfcloud/hcl_parser.py -input ${conf_lz} -env ${TF_VAR_environment})
     warning $conf_lz_json


### PR DESCRIPTION
aztfmod examples do not have var.landingzone variable which is required when splitting into multiple deployments with caf_solution