### PR TITLE
surround parse_parameters with quote to support parameters with space…

### DIFF
--- a/scripts/rover.sh
+++ b/scripts/rover.sh
@@ -63,7 +63,7 @@ __log_init__
 set_log_severity ERROR # Default Log Severity. This can be overriden via -log-severity or -d (shortcut for -log-severity DEBUG)
 
 # Parse command line parameters
-parse_parameters $@
+parse_parameters "$@"
 
 checkout_module
 verify_rover_version


### PR DESCRIPTION
Parameters with spaces are currently not supported, like state list, state rm etc.

Will fix the following Issues:

- https://github.com/aztfmod/rover/issues/322
- https://github.com/aztfmod/rover/issues/249
