### PR TITLE
Role activation failed when role is not enabled in new tenants

### DIFF
--- a/scripts/lib/aad_constants.sh
+++ b/scripts/lib/aad_constants.sh
@@ -12,3 +12,18 @@ declare -A apiPermissions=(
   ['Group.ReadWrite.All']='62a82d76-70ea-41e2-9197-370581804d09=Role'
   ['DelegatedPermissionGrant.ReadWrite.All']='8e8e4742-1d95-4f68-9d56-6ee75648c72a=Role'
 )
+
+for roleName in "${!roleTemplate[@]}"; do
+  roleTemplateId="${roleTemplate[$roleName]}"
+
+  # Check if the role is already enabled
+  enabled_role=$(az rest --method Get --uri ${microsoft_graph_endpoint}v1.0/directoryRoles -o json | jq -r ".value[] | select(.roleTemplateId == \"$roleTemplateId\")")
+
+  # If the role is not enabled, enable it
+  if [ -z "$enabled_role" ]; then
+    echo "Enabling role $roleName..."
+    az rest --method POST --uri https://graph.microsoft.com/v1.0/directoryRoles --body "{\"roleTemplateId\": \"$roleTemplateId\"}" --headers "Content-Type=application/json"
+  else
+    echo "Role $roleName is already enabled."
+  fi
+done

--- a/scripts/lib/azure_ad.sh
+++ b/scripts/lib/azure_ad.sh
@@ -50,7 +50,7 @@ create_federated_identity() {
     manage_sp_to_role "Privileged Role Administrator" ${sp_object_id} "POST"
     manage_sp_to_role "Application Administrator" ${sp_object_id} "POST"
     manage_sp_to_role "Groups Administrator" ${sp_object_id} "POST"
-  
+
   else
     success " - application already created."
     success " - service principal already created."
@@ -130,7 +130,7 @@ function manage_sp_to_role() {
   export ROLE_AAD=$(az rest --method Get --uri ${microsoft_graph_endpoint}v1.0/directoryRoles -o json | jq -r '.value[] | select(.displayName == "'"$(echo ${AD_ROLE_NAME})"'") | .id')
 
   if [ "${ROLE_AAD}" == '' ]; then
-      enable_directory_role
+      enable_directory_role ${AD_ROLE_NAME}
       export ROLE_AAD=$(az rest --method Get --uri ${microsoft_graph_endpoint}v1.0/directoryRoles -o json | jq -r '.value[] | select(.displayName == "'"$(echo ${AD_ROLE_NAME})"'") | .id')
   fi
 


### PR DESCRIPTION
Add logic to check if role is enabled, if not enabled enable it.

Fix issue when calling function enable_directory_role, add parameter with role name.