### PR TITLE
feat: allow .tfvars to be structured in subfolders

### DIFF
--- a/scripts/tfstate.sh
+++ b/scripts/tfstate.sh
@@ -26,7 +26,7 @@ function tfstate_configure {
 
             if [ ! -z ${TF_var_folder} ]; then
                 rm -rf -- "${landingzone_name}/caf.auto.tfvars" || true
-                for filename in ${TF_var_folder}/*.tfvars; do
+                find ${TF_var_folder} -name '*.tfvars' -type f | while read filename; do
                     command="cat ${filename} >> ${landingzone_name}/caf.auto.tfvars && printf '\n' >> ${landingzone_name}/caf.auto.tfvars"
                     debug ${command}
                     eval ${command}


### PR DESCRIPTION
With this change caf developers (especially on level 4) can structure their tfvars files into sub folders (networking, compute etc.). When running rover providing the `-var-folder` parameter now the provided folder and all subfolders will be searched for .tfvars files and used when running rover.

The rover CLI interface stays the same.

This change might break things when existing caf project structures have folders including tfvars next to tfvars files. As far as I can see this is not the case for asvm related projects.