### PR TITLE
Revert "Role activation failed when role is not enabled in new tenants"

### DIFF
--- a/scripts/lib/aad_constants.sh
+++ b/scripts/lib/aad_constants.sh
@@ -12,18 +12,3 @@ declare -A apiPermissions=(
   ['Group.ReadWrite.All']='62a82d76-70ea-41e2-9197-370581804d09=Role'
   ['DelegatedPermissionGrant.ReadWrite.All']='8e8e4742-1d95-4f68-9d56-6ee75648c72a=Role'
 )
-
-for roleName in "${!roleTemplate[@]}"; do
-  roleTemplateId="${roleTemplate[$roleName]}"
-
-  # Check if the role is already enabled
-  enabled_role=$(az rest --method Get --uri ${microsoft_graph_endpoint}v1.0/directoryRoles -o json | jq -r ".value[] | select(.roleTemplateId == \"$roleTemplateId\")")
-
-  # If the role is not enabled, enable it
-  if [ -z "$enabled_role" ]; then
-    echo "Enabling role $roleName..."
-    az rest --method POST --uri https://graph.microsoft.com/v1.0/directoryRoles --body "{\"roleTemplateId\": \"$roleTemplateId\"}" --headers "Content-Type=application/json"
-  else
-    echo "Role $roleName is already enabled."
-  fi
-done

--- a/scripts/lib/azure_ad.sh
+++ b/scripts/lib/azure_ad.sh
@@ -50,7 +50,7 @@ create_federated_identity() {
     manage_sp_to_role "Privileged Role Administrator" ${sp_object_id} "POST"
     manage_sp_to_role "Application Administrator" ${sp_object_id} "POST"
     manage_sp_to_role "Groups Administrator" ${sp_object_id} "POST"
-
+  
   else
     success " - application already created."
     success " - service principal already created."
@@ -130,7 +130,7 @@ function manage_sp_to_role() {
   export ROLE_AAD=$(az rest --method Get --uri ${microsoft_graph_endpoint}v1.0/directoryRoles -o json | jq -r '.value[] | select(.displayName == "'"$(echo ${AD_ROLE_NAME})"'") | .id')
 
   if [ "${ROLE_AAD}" == '' ]; then
-      enable_directory_role ${AD_ROLE_NAME}
+      enable_directory_role
       export ROLE_AAD=$(az rest --method Get --uri ${microsoft_graph_endpoint}v1.0/directoryRoles -o json | jq -r '.value[] | select(.displayName == "'"$(echo ${AD_ROLE_NAME})"'") | .id')
   fi
 


### PR DESCRIPTION
Rolling back as it seems to cause the following error with this PR. 
Have you seen this error before @heintonny? 

```
ERROR: The command failed with an unexpected error. Here is the traceback:
ERROR: HTTPSConnectionPool(host='management.azure.comv1.0', port=443): Max retries exceeded with url: /directoryRoles (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0xffff79ac8910>: Failed to establish a new connection: [Errno -2] Name or service not known'))
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/urllib3/connection.py", line 174, in _new_conn
    conn = connection.create_connection(
  File "/usr/local/lib/python3.10/dist-packages/urllib3/util/connection.py", line 72, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
  File "/usr/lib/python3.10/socket.py", line 955, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known

Enabling role Global Administrator...
Bad Request({"error":{"code":"Request_BadRequest","message":"A conflicting object with one or more of the specified property values is present in the directory.","details":[{"code":"ConflictingObjects","message":"A conflicting object with one or more of the specified property values is present in the directory.","target":"Role_54a07b52-3600-40b7-b421-a016d165c47d"}],"innerError":{"date":"2023-09-29T09:55:30","request-id":"
,"client-request-id":""}}})

```