### PR TITLE
Fix missing ARM_CLIENT_ID and ARM_TENANT_ID vars who is required when…

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -294,8 +294,13 @@ function verify_azure_session {
     if [ "$session" == '' ]; then
         display_login_instructions
         error ${LINENO} "you must login to an Azure subscription first or 'rover login' again" 2
+    else
+        # If the session is a OIDC service principal we need to export the ARM variables
+        if [ "${ARM_USE_OIDC}" == "true" ]; then
+            export ARM_CLIENT_ID=$(echo $session | jq -r '.user.name')
+            export ARM_TENANT_ID=$(echo $session | jq -r '.tenantId')
+        fi
     fi
-
 }
 
 function login_as_sp_from_keyvault_secrets {


### PR DESCRIPTION
When we use OIDC (GitHub) we need to export the ARM_CLIENT_ID and ARM_TENANT_ID

![image](https://github.com/aztfmod/rover/assets/20846272/afbda929-68d5-408b-969c-b344f9a558ae)
