### PR TITLE
Fix get msiResource for multi sub

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -587,7 +587,7 @@ function get_resource_from_assignedIdentityInfo {
         msiResource=${msi//MSIResource-/}
         ;;
     *"MSIClient"*)
-        msiResource=$(az identity list --query "[?clientId=='${msi//MSIClient-/}'].{id:id}" -o tsv --only-show-errors)
+        msiResource=$(az identity list --subscription ${TF_VAR_tfstate_subscription_id} --query "[?clientId=='${msi//MSIClient-/}'].{id:id}" -o tsv --only-show-errors)
         ;;
     *)
         echo "Warning: MSI identifier unknown."


### PR DESCRIPTION
Add tfstate_subscription_id parameter to az identity list when setting msiResource from assignedIdentityInfo

Fixes the following issue
https://github.com/aztfmod/rover/issues/350


