### PR TITLE
Add support for user-assigned managed identity login for TFE agent

### DIFF
--- a/agents/tfc/login.sh
+++ b/agents/tfc/login.sh
@@ -5,7 +5,13 @@ if [[ -v ARM_CLIENT_SECRET ]]; then
   az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET -t $ARM_TENANT_ID --allow-no-subscriptions >/dev/null >&1
 fi
 
-if [[ -v ARM_SUBSCRIPTION_ID ]]; then
+if [[ -v MSI-RESOURCE-ID ]]; then
+  echo "Logging with the user-assigned managed identity. ($MSI-RESOURCE-ID)"
+  az login --identity -u $(MSI-RESOURCE-ID) -t $ARM_TENANT_ID --allow-no-subscriptions >/dev/null >&1
+fi
+
+if [[ -v ARM_SUBSCRIPTION_ID ] || [ -v SUBSCRIPTION_ID ]]; then
+  ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID:="$SUBSCRIPTION_ID"}
   echo "Set the subscription to $ARM_SUBSCRIPTION_ID."
   az account set -s $ARM_SUBSCRIPTION_ID
   az account show -o json | jq


### PR DESCRIPTION
Add support for user-assigned managed identity to login, in addition to service principal.