### PR TITLE
Update login.sh to fix syntax error in if block

### DIFF
--- a/agents/tfc/login.sh
+++ b/agents/tfc/login.sh
@@ -5,12 +5,13 @@ if [[ -v ARM_CLIENT_SECRET ]]; then
   az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET -t $ARM_TENANT_ID --allow-no-subscriptions >/dev/null >&1
 fi
 
-if [[ -v MSI-RESOURCE-ID ]]; then
-  echo "Logging with the user-assigned managed identity. ($MSI-RESOURCE-ID)"
-  az login --identity -u $(MSI-RESOURCE-ID) -t $ARM_TENANT_ID --allow-no-subscriptions >/dev/null >&1
+if [[ -v MSI_RESOURCE_ID ]]; then
+  echo "Logging with the user-assigned managed identity. ($MSI_RESOURCE_ID)"
+  # need to set environment variables ARM_USE_MSI=true and ARM_CLIENT_ID=client_id_of_MSI_RESOURCE_ID
+  az login --identity --username $MSI_RESOURCE_ID --allow-no-subscriptions >/dev/null >&1
 fi
 
-if [[ -v ARM_SUBSCRIPTION_ID ] || [ -v SUBSCRIPTION_ID ]]; then
+if [[ -v ARM_SUBSCRIPTION_ID || -v SUBSCRIPTION_ID ]]; then
   ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID:="$SUBSCRIPTION_ID"}
   echo "Set the subscription to $ARM_SUBSCRIPTION_ID."
   az account set -s $ARM_SUBSCRIPTION_ID


### PR DESCRIPTION
Fix syntax error in if block
Correct az login command to allow log-in on user-assigned managed identity.